### PR TITLE
fix: button size + examples

### DIFF
--- a/src/assets/scss/buefy.scss
+++ b/src/assets/scss/buefy.scss
@@ -20,3 +20,4 @@
 @import './buefy/loading.scss';
 @import './buefy/timepicker';
 @import './buefy/radio.scss';
+@import './buefy/button.scss';

--- a/src/assets/scss/buefy/_button.scss
+++ b/src/assets/scss/buefy/_button.scss
@@ -1,0 +1,4 @@
+.button .button-wrapper {
+  display: inline-flex;
+  justify-content: center;
+}

--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -1,20 +1,33 @@
 <template>
-   <div class="buttons">
-        <o-button variant="primary">Primary</o-button>
-        <o-button variant="success">Success</o-button>
-        <o-button variant="danger">Danger</o-button>
-        <o-button variant="warning">Warning</o-button>
-        <o-button variant="info">Info</o-button>
-      </div>
+  <div class="buttons">
+    <o-button variant="primary">Primary</o-button>
+    <o-button variant="success">Success</o-button>
+    <o-button variant="danger">Danger</o-button>
+    <o-button variant="warning">Warning</o-button>
+    <o-button variant="info">Info</o-button>
+  </div>
 
-      <div class="buttons">
-        <o-button>Normal</o-button>
-        <o-button disabled>Disabled</o-button>
-        <o-button rounded>Rounded</o-button>
-      </div>
+  <div class="buttons">
+    <o-button>Normal</o-button>
+    <o-button disabled>Disabled</o-button>
+    <o-button rounded>Rounded</o-button>
+  </div>
 
-      <div class="buttons">
-        <o-button variant="primary" outlined>Outlined</o-button>
-        <o-button variant="primary" inverted>Inverted</o-button>
-      </div>
+  <div class="buttons">
+    <o-button variant="primary" outlined>Outlined</o-button>
+    <o-button variant="primary" inverted>Inverted</o-button>
+  </div>
+
+  <div class="buttons">
+    <o-button size="small" icon-left="plus">Add</o-button>
+    <o-button icon-left="plus">Add</o-button>
+    <o-button size="medium" icon-left="plus">Add</o-button>
+    <o-button size="large" icon-left="plus">Add</o-button>
+  </div>
+
+  <div class="buttons">
+    <o-button variant="danger" icon-left="trash">Delete</o-button>
+    <o-button variant="danger" icon-right="trash">Delete</o-button>
+    <o-button variant="danger" icon-right="trash"/>
+  </div>
 </template>

--- a/src/plugins/oruga.ts
+++ b/src/plugins/oruga.ts
@@ -266,10 +266,12 @@ export const bulmaConfig: any = {
     button: {
         override: true,
         rootClass: 'button',
+        sizeClass: 'is-',
         variantClass: 'is-',
         roundedClass: 'is-rounded',
         outlinedClass: () => 'is-outlined',
-        invertedClass: () => 'is-inverted'
+        invertedClass: () => 'is-inverted',
+        elementsWrapperClass: 'button-wrapper'
     },
     skeleton: {
         override: true,


### PR DESCRIPTION
fixes the content of large buttons not being centered.
I hope the naming of the wrapper class is ok?