### PR TITLE
fix: bottom border of active boxed tab

### DIFF
--- a/src/assets/scss/components/_tabs.scss
+++ b/src/assets/scss/components/_tabs.scss
@@ -20,7 +20,7 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                 outline: $tabs-focused-outline;
                 border-bottom-color: $tabs-link-focus-active-border-bottom-color;
             }
- 
+
             a {
                 &:not(.is-active) {
                     &:focus {
@@ -50,7 +50,7 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                         }
                     }
                 }
-                
+
             }
         }
         &.is-toggle {
@@ -67,7 +67,7 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                         }
                     }
                 }
-                
+
             }
         }
     }
@@ -125,7 +125,7 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                         &.is-active {
                             border-bottom-color: $tabs-border-bottom-color !important;
                             border-right-color: transparent !important;
-                        }    
+                        }
                     }
                 }
             }
@@ -181,14 +181,14 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                             border-left-color: $tabs-border-bottom-color !important;
                             border-radius: 0 $tabs-boxed-link-radius $tabs-boxed-link-radius 0;
                         }
-                        
+
                         a {
                             &.is-active {
                                 border-bottom-color: $tabs-border-bottom-color !important;
                                 border-right-color: $tabs-border-bottom-color !important;
                                 border-left-color: transparent !important;
                             }
-                            
+
                         }
                     }
                 }
@@ -204,13 +204,13 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
 
 
     // ul or li -> div
-    // a -> a 
+    // a -> a
 
     // Hack to Bulma (ul, li, .. style)
     .tabs {
-       
+
         div {
-           
+
             a {
                 height: 100%;
                 &.is-active {
@@ -219,7 +219,7 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                 }
             }
         }
-        
+
 
         // ul classes -> nav
         display: flex;
@@ -228,9 +228,11 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
         justify-content: flex-start;
 
         &:not(.is-toggle), &:not(.is-toggle-rounded) {
-            border-bottom-color: $tabs-border-bottom-color;
-            border-bottom-style: $tabs-border-bottom-style;
-            border-bottom-width: $tabs-border-bottom-width;
+            & div a:not(.is-active){
+                border-bottom-color: $tabs-border-bottom-color;
+                border-bottom-style: $tabs-border-bottom-style;
+                border-bottom-width: $tabs-border-bottom-width;
+            }
         }
 
         &.is-toggle, &.is-toggle-rounded {
@@ -270,7 +272,7 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
                         border-bottom-left-radius: $tabs-toggle-link-radius;
                     }
                 }
-                
+
                 a {
                     &.is-active {
                         background-color: $tabs-toggle-link-active-background-color;

--- a/src/assets/scss/components/_tabs.scss
+++ b/src/assets/scss/components/_tabs.scss
@@ -338,4 +338,22 @@ $tabs-toggle-link-focus-border-color: $tabs-toggle-link-hover-border-color !defa
             }
         }
     }
+
+    &.is-vertical {
+        > .tabs {
+            &:not(.is-boxed):not(.is-toggle):not(.is-toggle-rounded) {
+                & div a {
+                    border-right-color: $tabs-border-bottom-color;
+                    border-right-width: $tabs-border-bottom-width;
+                    border-right-style: $tabs-border-bottom-style;
+                    border-bottom-color: transparent !important;
+                    border-bottom-width: 0;
+                    border-bottom-style: unset;
+                    &.is-active {
+                        border-right-color: $tabs-link-active-border-bottom-color;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -27,6 +27,62 @@
             vehicula pulvinar tellus, id sodales felis lobortis eget.
         </o-tab-item>
     </o-tabs>
+    <o-tabs v-model="activeTab" multiline type="boxed">
+    <o-tab-item :value="0" label="Pictures">
+      Lorem ipsum dolor sit amet.
+    </o-tab-item>
+
+    <o-tab-item :value="1" label="Music">
+      Lorem <br />
+      ipsum <br />
+      dolor <br />
+      sit <br />
+      amet.
+    </o-tab-item>
+
+    <o-tab-item :value="2" label="Books">
+      What light is light, if Silvia be not seen? <br />
+      What joy is joy, if Silvia be not by— <br />
+      Unless it be to think that she is by <br />
+      And feed upon the shadow of perfection? <br />
+      Except I be by Silvia in the night, <br />
+      There is no music in the nightingale.
+    </o-tab-item>
+
+    <o-tab-item :value="3" label="Videos" icon="video" disabled>
+      Nunc nec velit nec libero vestibulum eleifend. Curabitur pulvinar
+      congue luctus. Nullam hendrerit iaculis augue vitae ornare. Maecenas
+      vehicula pulvinar tellus, id sodales felis lobortis eget.
+    </o-tab-item>
+  </o-tabs>
+    <o-tabs v-model="activeTab" multiline type="toggle" >
+    <o-tab-item :value="0" label="Pictures">
+      Lorem ipsum dolor sit amet.
+    </o-tab-item>
+
+    <o-tab-item :value="1" label="Music">
+      Lorem <br />
+      ipsum <br />
+      dolor <br />
+      sit <br />
+      amet.
+    </o-tab-item>
+
+    <o-tab-item :value="2" label="Books">
+      What light is light, if Silvia be not seen? <br />
+      What joy is joy, if Silvia be not by— <br />
+      Unless it be to think that she is by <br />
+      And feed upon the shadow of perfection? <br />
+      Except I be by Silvia in the night, <br />
+      There is no music in the nightingale.
+    </o-tab-item>
+
+    <o-tab-item :value="3" label="Videos" icon="video" disabled>
+      Nunc nec velit nec libero vestibulum eleifend. Curabitur pulvinar
+      congue luctus. Nullam hendrerit iaculis augue vitae ornare. Maecenas
+      vehicula pulvinar tellus, id sodales felis lobortis eget.
+    </o-tab-item>
+  </o-tabs>
 </template>
 
 <script lang="ts">

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -83,6 +83,90 @@
       vehicula pulvinar tellus, id sodales felis lobortis eget.
     </o-tab-item>
   </o-tabs>
+  <o-tabs v-model="activeTab" multiline vertical>
+    <o-tab-item :value="0" label="Pictures">
+      Lorem ipsum dolor sit amet.
+    </o-tab-item>
+
+    <o-tab-item :value="1" label="Music">
+      Lorem <br />
+      ipsum <br />
+      dolor <br />
+      sit <br />
+      amet.
+    </o-tab-item>
+
+    <o-tab-item :value="2" label="Books">
+      What light is light, if Silvia be not seen? <br />
+      What joy is joy, if Silvia be not by— <br />
+      Unless it be to think that she is by <br />
+      And feed upon the shadow of perfection? <br />
+      Except I be by Silvia in the night, <br />
+      There is no music in the nightingale.
+    </o-tab-item>
+
+    <o-tab-item :value="3" label="Videos" icon="video" disabled>
+      Nunc nec velit nec libero vestibulum eleifend. Curabitur pulvinar
+      congue luctus. Nullam hendrerit iaculis augue vitae ornare. Maecenas
+      vehicula pulvinar tellus, id sodales felis lobortis eget.
+    </o-tab-item>
+  </o-tabs>
+  <o-tabs v-model="activeTab" multiline type="boxed" vertical>
+    <o-tab-item :value="0" label="Pictures">
+      Lorem ipsum dolor sit amet.
+    </o-tab-item>
+
+    <o-tab-item :value="1" label="Music">
+      Lorem <br />
+      ipsum <br />
+      dolor <br />
+      sit <br />
+      amet.
+    </o-tab-item>
+
+    <o-tab-item :value="2" label="Books">
+      What light is light, if Silvia be not seen? <br />
+      What joy is joy, if Silvia be not by— <br />
+      Unless it be to think that she is by <br />
+      And feed upon the shadow of perfection? <br />
+      Except I be by Silvia in the night, <br />
+      There is no music in the nightingale.
+    </o-tab-item>
+
+    <o-tab-item :value="3" label="Videos" icon="video" disabled>
+      Nunc nec velit nec libero vestibulum eleifend. Curabitur pulvinar
+      congue luctus. Nullam hendrerit iaculis augue vitae ornare. Maecenas
+      vehicula pulvinar tellus, id sodales felis lobortis eget.
+    </o-tab-item>
+  </o-tabs>
+  <o-tabs v-model="activeTab" multiline type="toggle" vertical>
+    <o-tab-item :value="0" label="Pictures">
+      Lorem ipsum dolor sit amet.
+    </o-tab-item>
+
+    <o-tab-item :value="1" label="Music">
+      Lorem <br />
+      ipsum <br />
+      dolor <br />
+      sit <br />
+      amet.
+    </o-tab-item>
+
+    <o-tab-item :value="2" label="Books">
+      What light is light, if Silvia be not seen? <br />
+      What joy is joy, if Silvia be not by— <br />
+      Unless it be to think that she is by <br />
+      And feed upon the shadow of perfection? <br />
+      Except I be by Silvia in the night, <br />
+      There is no music in the nightingale.
+    </o-tab-item>
+
+    <o-tab-item :value="3" label="Videos" icon="video" disabled>
+      Nunc nec velit nec libero vestibulum eleifend. Curabitur pulvinar
+      congue luctus. Nullam hendrerit iaculis augue vitae ornare. Maecenas
+      vehicula pulvinar tellus, id sodales felis lobortis eget.
+    </o-tab-item>
+  </o-tabs>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Proposed fix: remove the bottom border of `div.tabs` and add it to the `a`-tags
side effect: the border is not over the whole width but only over the actual tabs, but I think that's ok?