### PR TITLE
Add labelSizeClass to fields

### DIFF
--- a/src/plugins/bulma.ts
+++ b/src/plugins/bulma.ts
@@ -5,6 +5,7 @@ export const bulmaConfig: any = {
         override: true,
         rootClass: 'field',
         labelClass: 'label',
+        labelSizeClass: 'is-',
         messageClass: 'help',
         variantMessageClass: 'is-',
         addonsClass: 'has-addons',


### PR DESCRIPTION
The configuration for fields seems to have been missing `labelSizeClass`.