### PR TITLE
fix: Add datepicker classes for monthly mode

### DIFF
--- a/src/plugins/bulma.ts
+++ b/src/plugins/bulma.ts
@@ -362,6 +362,10 @@ export const bulmaConfig: any = {
         tableEventVariantClass: 'is-',
         tableEventsClass: 'events',
         tableEventClass: 'event',
+        monthClass: 'datepicker-table',
+        monthBodyClass: 'datepicker-body',
+        monthTableClass: 'datepicker-months',
+        monthCellClass: 'datepicker-cell'
     },
     modal: {
         override: true,


### PR DESCRIPTION
I was messing around with this library and noticed that when the datepicker was created in monthly mode, the styling broke (also reported in https://github.com/oruga-ui/theme-bulma/issues/71).

From inspecting the DOM tree it looked like none of the classes were set, so this explicitly adds the class props in the bulma config.

A screenshot of how it looked for me when I did it [using the override](https://github.com/oruga-ui/theme-bulma/issues/71#issuecomment-1345589868)

<img width="289" alt="Screen Shot 2022-12-11 at 9 54 41 AM" src="https://user-images.githubusercontent.com/14264791/206918643-43ab1d8f-00cd-42ed-92a6-f7860ac64d97.png">

I'm not sure if there's a better way to fix this or if it's a bug in the Oruga lib itself when it generates classes, though, so worth a review!