### PR TITLE
form: fix loading ::after for rtl

### DIFF
--- a/src/assets/scss/components/_form.scss
+++ b/src/assets/scss/components/_form.scss
@@ -353,6 +353,8 @@ $floating-in-height: 3.25em !default;
     // fix Bulma 0.8.2
     &.is-loading::after {
         top: calc(50% - (1em / 2));
-        right: calc((2.5em / 2) - .5em);
+        @include ltr {
+            right: calc((2.5em / 2) - .5em);
+        }
     }
 }


### PR DESCRIPTION
This brings back the icon to the left hand side when rtl is turned on.