### PR TITLE
fix(steps): move step divider for rtl

### DIFF
--- a/src/assets/scss/components/_steps.scss
+++ b/src/assets/scss/components/_steps.scss
@@ -213,7 +213,12 @@ $steps-colors: $colors !default;
                         position: absolute;
                         width: 100%;
                         bottom: 0;
-                        left: -50%;
+                        @include ltr {
+                            left: -50%;
+                        }
+                        @include rtl {
+                            left: 50%;
+                        }
                     }
                 }
                 &:only-child {


### PR DESCRIPTION
Puts the divider on the right hand side of the current step, rather than its left.

before: https://user-images.githubusercontent.com/1277636/213305240-343871cb-d98b-4062-ae84-3b6ae8d87420.png after: https://imgur.com/QHiieY7

This doesn't fix the remaining issues with the animations going the wrong way for RTL (https://github.com/oruga-ui/oruga/issues/474).