### PR TITLE
Bugfix: Unfocused background page should not be scrollable while modal is open.

### DIFF
--- a/src/plugins/bulma.ts
+++ b/src/plugins/bulma.ts
@@ -389,7 +389,9 @@ export const bulmaConfig: any = {
         overlayClass: 'modal-background',
         contentClass: 'modal-content animation-content',
         closeClass: 'modal-close is-large',
-        fullScreenClass: 'is-full-screen'
+        fullScreenClass: 'is-full-screen',
+        noScrollClass: { override: false },
+        scrollClipClass: { override: false }
     },
     sidebar: {
         override: true,

--- a/src/plugins/bulma.ts
+++ b/src/plugins/bulma.ts
@@ -390,8 +390,8 @@ export const bulmaConfig: any = {
         contentClass: 'modal-content animation-content',
         closeClass: 'modal-close is-large',
         fullScreenClass: 'is-full-screen',
-        noScrollClass: { override: false },
-        scrollClipClass: { override: false }
+        noScrollClass: 'is-clipped',
+        scrollClipClass: 'is-clipped'
     },
     sidebar: {
         override: true,

--- a/src/plugins/bulma.ts
+++ b/src/plugins/bulma.ts
@@ -390,7 +390,6 @@ export const bulmaConfig: any = {
         contentClass: 'modal-content animation-content',
         closeClass: 'modal-close is-large',
         fullScreenClass: 'is-full-screen',
-        noScrollClass: 'is-clipped',
         scrollClipClass: 'is-clipped'
     },
     sidebar: {


### PR DESCRIPTION
Bug in oruga overrides causes Modal.vue computed -> `scrollClass` to always be `''` which means that the no scroll behavior gets broken when theme-bulma is installed.

---

For what it's worth, I actually think the behavior of `computedClass(field: string, defaultValue: string, suffix: string = '')` in `BaseComponentMixin` is kinda bad design.

In order to keep from breaking your component each time oruga adds a customizable class, you'll need to update this repo, which seems quite error prone and appears to be what happened here.

```ts
// This line serves no purpose and should be removed
const overrideClass = getValueByPath(config, `${this.$options.configField}.${field}.override`, override)

// ... Later in the file, remove the usage of overrideClass and allow the default value to be used even IF `override = true` if there's no explicit override class defined in the config object.
let appliedClasses = /* ... rewrite this ... */
```