### PR TITLE
fix(table-sticky-header): add class has-sticky-header

### DIFF
--- a/src/plugins/bulma.ts
+++ b/src/plugins/bulma.ts
@@ -188,6 +188,7 @@ export const bulmaConfig: any = {
         footerClass: 'table-footer',
         paginationWrapperClass: 'level',
         scrollableClass: 'table-container',
+        stickyHeaderClass: 'has-sticky-header',
         trSelectedClass: 'is-selected',
         thSortableClass: 'is-sortable',
         thCurrentSortClass: 'is-current-sort',


### PR DESCRIPTION
Fix : https://github.com/oruga-ui/theme-bulma/issues/63 

Add the missing class in the `bulmaConfig`.