### PR TITLE
build: align `@oruga-ui/oruga-next` dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,9 @@
         "vue": "3.4.34",
         "vue-router": "4.4.3",
         "vue-tsc": "2.1.6"
+      },
+      "peerDependencies": {
+        "@oruga-ui/oruga-next": "0.9.0-pre.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "update": "ncu -u"
   },
   "peerDependencies": {
-    "@oruga-ui/oruga-next": "0.9.0-pre.1"
+    "@oruga-ui/oruga-next": "0.9.0-pre.2"
   },
   "dependencies": {
     "bulma": "1.0.2"


### PR DESCRIPTION
This is needed as oruga-next `isTrueish` is not available in `0.9.0-pre.1` dist.

Fix #136 