### PR TITLE
fix(field): floating label background color

### DIFF
--- a/src/assets/scss/components/_field.scss
+++ b/src/assets/scss/components/_field.scss
@@ -1,4 +1,5 @@
 @use "bulma/sass/utilities/css-variables" as css;
+@use "bulma/sass/form/shared" as form;
 @use "bulma/sass/utilities/mixins" as mixins;
 
 /* @docs */
@@ -201,7 +202,14 @@ $floating-in-height: 3.25em !default;
                 left: 0;
                 right: 0;
                 height: 0.375em;
-                background-color: css.getVar("input-background-l");
+                background-color: hsl(
+                    form.$input-h,
+                    form.$input-s,
+                    calc(
+                        form.$input-background-l +
+                            form.$input-background-l-delta
+                    )
+                );
                 z-index: -1;
             }
         }


### PR DESCRIPTION
`background-color` is improperly set to a non color value in `_field.scss` for floating-label
This PR fixes this by using the same formula as used for `input-background-color` in bulma/sass/form/shared