### PR TITLE
fix(button): solve focus variant color issues

### DIFF
--- a/src/assets/scss/components/_button.scss
+++ b/src/assets/scss/components/_button.scss
@@ -1,29 +1,17 @@
 @use "bulma/sass/utilities/css-variables" as css;
 
-/* @docs */
-$button-shadow: css.getVar("focus-shadow-size")
-    hsla(
-        css.getVar("button-h"),
-        css.getVar("button-s"),
-        css.getVar("button-l"),
-        css.getVar("focus-shadow-alpha")
-    );
-/* @docs */
-
 .button {
     @include css.register-vars(
         (
-            "button-shadow": #{$button-shadow},
             "button-l": css.getVar("button-color-l"),
+            "focus-h": css.getVar("button-h"),
+            "focus-s": css.getVar("button-s"),
+            "focus-l": css.getVar("button-l"),
         )
     );
 
     .button-wrapper {
         display: inline-flex;
         justify-content: center;
-    }
-
-    &:focus {
-        box-shadow: css.getVar("button-shadow");
     }
 }


### PR DESCRIPTION
This PR addresses a few minor bugs with button focus states

## Focus vs Focus-Visible

Bulma prior to 1.0 uses :focus to control the focus ring on buttons but 1.0 switches to using :focus-visible. Theme-bulma has long overridden this focus style, but we didn't switch the override to focus-visible when we added support for Bulma 1.0. The result is the focus ring is a different color depending on how it is focused.

https://github.com/user-attachments/assets/7339a198-374a-4721-8d1f-7a3082abda24

## Blue border with keyboard focus

The other issue is that our override misses the blue border coming from Bulma.


https://github.com/user-attachments/assets/3ed17c72-595e-4581-b513-b900913a6f18

## The fix
This PR removes the :focus override completely, along with related variables. Instead, it sets the focus-* css variables to button colors. The resulting focus ring is identical but now flows through Bulma's focus-visible code so there's no mis-match. This also sets the border color.