### PR TITLE
fix(sidebar): solve broken open/close animations

### DIFF
--- a/src/assets/scss/components/_sidebar.scss
+++ b/src/assets/scss/components/_sidebar.scss
@@ -23,7 +23,6 @@
         width: css.getVar("sidebar-width");
         height: css.getVar("sidebar-height");
         position: fixed;
-        transition: width vars.$speed-slow css.getVar("easing");
         z-index: css.getVar("sidebar-z");
 
         @each $name, $pair in vars.$sidebar-colors {

--- a/src/assets/scss/components/_sidebar.scss
+++ b/src/assets/scss/components/_sidebar.scss
@@ -103,6 +103,7 @@
 
         &.is-mini {
             width: css.getVar("sidebar-mobile-width");
+            transition: width vars.$speed-slow css.getVar("easing");
 
             &.is-expanded:hover:not(.is-fullwidth) {
                 width: css.getVar("sidebar-width");

--- a/src/main-combined.scss
+++ b/src/main-combined.scss
@@ -6,7 +6,6 @@
         "fooooo": #f00,
     ),
     $black: #000,
-    $speed-slower: 1ms,
     $dropdown-content-max-height: 300px,
     // breaks
     //$carousel-arrow-color: #f00,

--- a/src/main-separated.scss
+++ b/src/main-separated.scss
@@ -6,7 +6,6 @@ $red: #f00;
 $black: #000;
 $secondary: rgb(0, 103, 134);
 $dark-grey: #6c757d;
-$speed-slower: 1000ms;
 
 // The theme adds a secondary color variant and should allow the user to add additional color variants if they desire
 // In the full bulma build this can happen internally, but if the user wants separated styles they need to handle this themselves
@@ -27,6 +26,5 @@ $custom-colors: (
 
 // Pass any theme values you'd like to override here. Bulma values like $primary will be passed implicitly into the theme build and do not need to be passed.
 @forward "assets/scss/components-build.scss" with (
-    $speed-slower: $speed-slower,
     $dropdown-content-max-height: 300px
 );


### PR DESCRIPTION
In the current version the sidebar opens and closes without issue but it does not animate. The root cause is [this line](https://github.com/oruga-ui/theme-bulma/blob/4ca8ca857696da4bae173dde13d7faf27aeae984/src/assets/scss/components/_sidebar.scss#L26), which overrides the transition specified by the `.slide-*` animation classes, which are applied by the sidebar's transition component. 

The width transition appears to exist to power the expanded/reduced version of the inline sidebar, which does not use the slide transition, so I have shifted the transition under `.is-mini`. 

I also cleaned up some test vars I left in the test layouts so visual testing is more accurate.