### PR TITLE
fix(input): solve Input icon no longer shows Bulma hover/focus styles on left icon

### DIFF
--- a/src/assets/scss/components/_input.scss
+++ b/src/assets/scss/components/_input.scss
@@ -56,19 +56,15 @@
     }
 
     // Re-creates the left icon style of https://github.com/jgthms/bulma/blob/main/sass/form/tools.scss#L275 to fit Oruga-style markup
-    &.has-icons-left {
-        .icon {
-            &:has(+ .input:hover),
-            &:has(+ .select:hover) {
-                color: css.getVar("input-icon-hover-color");
-            }
+    &.has-icons-left .icon {
+        &:has(+ .input:hover),
+        &:has(+ .select:hover) {
+            color: css.getVar("input-icon-hover-color");
         }
-
-        .icon {
-            &:has(+ .input:focus),
-            &:has(+ .select:focus) {
-                color: css.getVar("input-icon-focus-color");
-            }
+  
+        &:has(+ .input:focus),
+        &:has(+ .select:focus) {
+            color: css.getVar("input-icon-focus-color");
         }
     }
 }

--- a/src/assets/scss/components/_input.scss
+++ b/src/assets/scss/components/_input.scss
@@ -54,4 +54,21 @@
             }
         }
     }
+
+    // Re-creates the left icon style of https://github.com/jgthms/bulma/blob/main/sass/form/tools.scss#L275 to fit Oruga-style markup
+    &.has-icons-left {
+        .icon {
+            &:has(+ .input:hover),
+            &:has(+ .select:hover) {
+                color: css.getVar("input-icon-hover-color");
+            }
+        }
+
+        .icon {
+            &:has(+ .input:focus),
+            &:has(+ .select:focus) {
+                color: css.getVar("input-icon-focus-color");
+            }
+        }
+    }
 }


### PR DESCRIPTION
Bulma supports adding hover and focus colors to input icons. Oruga has long supported this, but in the recent rewrites this functionality regressed. This PR fixes the problem.

Example of correct behaviour from [Bulma docs](https://bulma.io/documentation/form/input/#with-font-awesome-icons)

https://github.com/user-attachments/assets/1255d326-07c2-4fd1-a38b-4eaeb07f9b4c

Example of incorrect behaviour from Oruga docs


https://github.com/user-attachments/assets/1bb5e9ee-29b8-42f1-9d75-3219e203eba7


## What broke?

Bulma targets this style with a subsequent sibling selector sort of like this

```
.input:focus ~ .icon {
color:red;
}
```

When the input component was re-written the order of the input dom elements changed, going from `input, left icon, right icon` to `left icon, input, right icon`. This is totally logical since DOM order reflects visual order, but it breaks the Bulma selector for the left icon since it now comes **before** the focused input.

Related: https://github.com/oruga-ui/oruga/pull/1271

## Proposed Changes

- Adds styles to restore left icon hover/focus states